### PR TITLE
Fix client entity being controlled after disconnect

### DIFF
--- a/include/librg.h
+++ b/include/librg.h
@@ -2331,6 +2331,7 @@ extern "C" {
                     /* reset controlled flag, otherwise it will be called while being disconnected */
                     librg_entity *blob = librg_entity_fetch(msg->ctx, i);
                     blob->flags &= ~LIBRG_ENTITY_CONTROLLED;
+                    blob->control_generation = 0;
 
                     continue;
                 }

--- a/include/librg.h
+++ b/include/librg.h
@@ -2327,7 +2327,13 @@ extern "C" {
                 if (!librg_entity_valid(msg->ctx, i)) continue;
 
                 /* skip our local entity from being inlcuded */
-                if (local && *local == i) continue;
+                if (local && *local == i) {
+                    /* reset controlled flag, otherwise it will be called while being disconnected */
+                    librg_entity *blob = librg_entity_fetch(msg->ctx, i);
+                    blob->flags &= ~LIBRG_ENTITY_CONTROLLED;
+
+                    continue;
+                }
 
                 librg_event event = {0}; {
                     event.entity = librg_entity_fetch(msg->ctx, i);


### PR DESCRIPTION
Fixes #17 
Fixes #16 

I realized only the client entity is triggering updates after disconnect, since it is not removed.