### PR TITLE
Fix unknown compiler option with cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.1.3)
 project(librg)
 
 find_package(Threads)
@@ -17,13 +17,9 @@ endif()
 add_library(librg INTERFACE)
 
 # add those compile flags badboys
-if (UNIX)
-    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=gnu99")
-    set(CMAKE_CXX_FLAGS "${CMAKE_C_FLAGS} -std=c++11")
-else()
-    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=c99")
-    set(CMAKE_CXX_FLAGS "${CMAKE_C_FLAGS} -std=c++11")
-endif()
+set(CMAKE_C_STANDARD 99)
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 # proxy our includes to outside world
 target_include_directories(librg INTERFACE include


### PR DESCRIPTION
When compiling with cmake (at least on windows) and msvc the compiler gives a warning
```cl : Command line warning D9002 : ignoring unknown option '-std=c99'```

When using proper cmake language standards the settings are correctly set for all compilers. To be able to set all flags the minimum cmake version needs to be increased from 3.0 to 3.1.3 (which is still pretty old and shouldn't make a difference at all).